### PR TITLE
feat(report): Make title configurable and remove footer

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -25,6 +25,8 @@ branch = main
 template_path = templates/report_template.html
 # 生成报告的输出目录
 output_dir = output/reports/
+# 项目名称，用于报告标题
+project_name = 总控平台
 
 [analysis]
 # 定义分析时使用的参数

--- a/config_loader.py
+++ b/config_loader.py
@@ -17,6 +17,7 @@ class Config:
         self.branch = config_data['git']['branch']
         self.template_path = config_data['report']['template_path']
         self.report_output_dir = config_data['report']['output_dir']
+        self.project_name = config_data['report'].get('project_name', '项目')
         self.overdue_threshold_days = int(config_data['analysis']['overdue_threshold_days'])
         
         # 处理可能为空的 target_tags

--- a/data/history.csv
+++ b/data/history.csv
@@ -1,2 +1,3 @@
 date,total_issues,resolved_issues,unresolved_issues,Medium,Critical,Low,Blocker,High,total,module_Algorithm,module_Camera,module_Gallery,module_UI,module_Auth
 2025-06-24,,,,45.0,43.0,41.0,36.0,35.0,200.0,41.0,34.0,30.0,28.0,24.0
+2025-06-26,,,,45.0,43.0,41.0,36.0,35.0,200.0,41.0,34.0,30.0,28.0,24.0

--- a/main.py
+++ b/main.py
@@ -95,6 +95,7 @@ def main():
 
         # 7. 准备报告上下文
         report_context = {
+            "project_name": config.project_name,
             "analysis": analysis_results,
             "charts": charts_html, # 这里现在是包含HTML的字典
             "data_file": os.path.basename(args.input_file),

--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>项目开发日报 - {{ report_date }}</title>
+    <title>{{ context.project_name }}开发日报 - {{ context.report_date }}</title>
     <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
@@ -35,8 +35,8 @@
 </head>
 <body>
     <div class="container">
-        <h1>项目开发日报</h1>
-        <p style="text-align: center; color: #666;">报告生成时间: {{ report_date }} | 数据来源: {{ context.data_file }}</p>
+        <h1>{{ context.project_name }}开发日报</h1>
+        <p style="text-align: center; color: #666;">报告生成时间: {{ context.report_date }} | 数据来源: {{ context.data_file }}</p>
 
         {% set kpis = context.analysis.kpis %}
         {# 预先定义颜色变量以避免linter在style属性中报错 #}
@@ -226,7 +226,7 @@
         </div>
 
         <div class="footer">
-            <p>由 JIRA 分析助手自动生成</p>
+            
         </div>
     </div>
     <script src="https://code.jquery.com/jquery-3.7.0.js"></script>


### PR DESCRIPTION
            本次更新对报告UI进行了两项优化：

            1.  **项目名称可配置**：报告标题现在会读取 `config.ini` 文件中的 `project_name` 配置，不再是硬编码。
            2.  **移除页脚**：删除了报告末尾 "由 JIRA 分析助手自动生成" 的文字。