### PR TITLE
fix(report): 修复图表显示并优化布局

### DIFF
--- a/templates/report_template.html
+++ b/templates/report_template.html
@@ -32,6 +32,16 @@
     .footer { text-align: center; margin-top: 40px; padding-top: 20px; border-top: 1px solid #ccc; font-size: 0.9em; color: #666; }
     .collapsible-table summary { font-weight: bold; cursor: pointer; padding: 10px; background-color: #f8f9fa; border: 1px solid #dee2e6; border-radius: 5px; margin-top: 10px; }
     tfoot input { width: 100%; padding: 3px; box-sizing: border-box; }
+    .chart-item {
+        flex: 1 1 33%;
+        background-color: #fff;
+        border-radius: 8px;
+        padding: 10px;
+        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+        display: flex;
+        flex-direction: column;
+        justify-content: flex-start;
+    }
 </style>
 </head>
 <body>
@@ -45,10 +55,10 @@
         
         <div class="card">
             <h2><i class="fas fa-tachometer-alt"></i> 核心KPI仪表盘</h2>
-            <!-- Row 1: 3-column grid for main KPIs -->
-            <div class="kpi-grid-container" style="grid-template-columns: repeat(3, 1fr); gap: 20px; align-items: stretch; margin-bottom: 20px;">
+            <!-- Row 1: 4-column grid for main KPIs and Trend Chart -->
+            <div class="kpi-grid-container" style="grid-template-columns: 0.8fr 1fr 0.8fr 3fr; gap: 15px; align-items: stretch; margin-bottom: 20px;">
                 <!-- Card 1: Convergence Deviation -->
-                <div class="kpi-card-large" style="grid-column: span 1;">
+                <div class="kpi-card-large" style="grid-column: span 1; display: flex; flex-direction: column; justify-content: space-between;">
                     <div class="kpi-title-large">收敛偏差</div>
                     {% if kpis.convergence_deviation and kpis.convergence_deviation > 0 %}
                     <div class="kpi-value-large" style="color: #dc3545;"><i class="fas fa-arrow-up"></i> +{{ kpis.convergence_deviation }}</div>
@@ -62,36 +72,45 @@
                     {% endif %}
                 </div>
                 <!-- Card 2: 7-Day Change -->
-                <div class="kpi-card-large" style="grid-column: span 1;">
+                <div class="kpi-card-large" style="grid-column: span 1; display: flex; flex-direction: column; justify-content: space-between; text-align: center;">
                     <div class="kpi-title-large">A类问题7日变化</div>
-                    {% if kpis.a_issues_7_day_change > 0 %}
-                    <div class="kpi-value-large" style="color: #dc3545;"><i class="fas fa-chart-line"></i> +{{ kpis.a_issues_7_day_change }}</div>
-                    {% else %}
-                    <div class="kpi-value-large" style="color: #28a745;"><i class="fas fa-chart-line"></i> {{ kpis.a_issues_7_day_change }}</div>
-                    {% endif %}
-                    <div class="kpi-context">{{ '有历史数据对比' if kpis.a_issues_7_day_change_has_history else '历史数据不足7天' }}</div>
+                    <div class="kpi-value-large" style="color: {{ kpis.weekly_change_color }}; padding: 0.1em 0;">
+                        <i class="fas fa-chart-line"></i>
+                    </div>
+                    <div class="kpi-context" style="color: {{ kpis.weekly_change_color }}; font-weight: bold;">
+                        {% if kpis.a_issues_7_day_change > 0 %}+{% endif %}{{ kpis.a_issues_7_day_change }}
+                    </div>
                 </div>
                 <!-- Card 3: JIRA/DI -->
-                <div class="kpi-card-large" style="grid-column: span 1; text-align: center; display: flex; flex-direction: column; justify-content: center;">
-                    <div style="margin-bottom: 15px;">
+                <div class="kpi-card-large" style="grid-column: span 1; text-align: center; display: flex; flex-direction: column; justify-content: space-between;">
+                    <div>
                         <div class="kpi-value-small">{{ kpis.total_issues }}</div>
                         <div class="kpi-context-small">JIRA总数量</div>
                     </div>
+                    <div style="border-top: 1px solid #eee; margin: 15px 20px;"></div>
                     <div>
                         <div class="kpi-value-small">{{ kpis.di_score }}</div>
                         <div class="kpi-context-small">DI</div>
                     </div>
                 </div>
+                <!-- Card 4: Trend Chart -->
+                <div class="kpi-card-large" style="grid-column: span 1; padding: 10px;">
+                    <div class="kpi-title-large" style="margin-bottom: 5px;">问题总体趋势</div>
+                    {{ (context.charts.trend_chart_html if context.charts.trend_chart_html else '<div class="kpi-context" style="text-align:center; padding-top: 50px;">无趋势数据</div>')|safe }}
+                </div>
             </div>
-            <!-- Row 2: 3-column grid for distribution charts -->
-            <div class="kpi-grid-container" style="grid-template-columns: repeat(3, 1fr); gap: 20px;">
-                <div class="kpi-card-small" style="padding: 0;">
+            <!-- Row 2: 3-column flexbox for distribution charts -->
+            <div class="chart-container" style="display: flex; flex-direction: row; justify-content: space-between; gap: 20px;">
+                <div class="chart-item">
+                    <div class="kpi-title-large" style="text-align: center; margin-bottom: 5px;">各模块问题分布</div>
                     {{ (context.charts.module_dist_html if context.charts.module_dist_html else '<div class="kpi-context" style="text-align:center; padding-top: 50px;">无模块数据</div>')|safe }}
                 </div>
-                <div class="kpi-card-small" style="padding: 0;">
+                <div class="chart-item">
+                    <div class="kpi-title-large" style="text-align: center; margin-bottom: 5px;">问题优先级分布</div>
                     {{ (context.charts.priority_dist_html if context.charts.priority_dist_html else '<div class="kpi-context" style="text-align:center; padding-top: 50px;">无优先级数据</div>')|safe }}
                 </div>
-                <div class="kpi-card-small" style="padding: 0;">
+                <div class="chart-item">
+                    <div class="kpi-title-large" style="text-align: center; margin-bottom: 5px;">Top 3 风险模块分布</div>
                     {{ (context.charts.top_3_riskiest_modules_html if context.charts.top_3_riskiest_modules_html else '<div class="kpi-context" style="text-align:center; padding-top: 50px;">无风险模块数据</div>')|safe }}
                 </div>
             </div>

--- a/visualizer.py
+++ b/visualizer.py
@@ -249,10 +249,11 @@ def _get_trend_chart_html(history_df: pd.DataFrame, a_priority_name: str) -> str
         ))
 
     fig.update_layout(
-        title="总体问题趋势",
-        xaxis_title="日期",
-        yaxis_title="问题数量",
-        margin=dict(t=40, l=20, r=20, b=20),
+        title_text="",
+        xaxis_title="",
+        yaxis_title="",
+        height=160,
+        margin=dict(t=20, l=40, r=20, b=40),
         legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1)
     )
     return pio.to_html(fig, full_html=False, include_plotlyjs=False)
@@ -260,26 +261,35 @@ def _get_trend_chart_html(history_df: pd.DataFrame, a_priority_name: str) -> str
 
 def _get_module_distribution_chart_html(module_data: dict) -> str:
     """
-    Generate Plotly pie chart HTML from module data.
+    Generate Plotly horizontal bar chart HTML from module data.
     """
     if not module_data:
         return None
 
-    module_series = pd.Series(module_data).sort_values(ascending=False)
+    module_series = pd.Series(module_data).sort_values(ascending=True)
 
-    fig = go.Figure(data=[go.Pie(
-        labels=module_series.index,
-        values=module_series.values,
-        hole=.3,
-        hoverinfo='label+percent+value',
-        textinfo='percent+label'
-    )])
+    fig = go.Figure()
+
+    fig.add_trace(go.Bar(
+        y=module_series.index,
+        x=module_series.values,
+        text=module_series.values,
+        textposition='auto',
+        orientation='h',
+        marker_color='rgba(54, 162, 235, 0.8)',
+        marker_line_color='rgba(54, 162, 235, 1)',
+        marker_line_width=1.5,
+    ))
 
     fig.update_layout(
-        title_text="各模块问题分布",
-        margin=dict(t=40, l=20, r=20, b=20),
-        showlegend=False,
-        height=200
+        title_text="",
+        xaxis_title="问题数量",
+        yaxis_title="模块",
+        height=240,
+        margin=dict(l=100, r=20, t=20, b=40),
+        xaxis=dict(showgrid=True, zeroline=True, showticklabels=True),
+        yaxis=dict(showgrid=False, zeroline=False, showticklabels=True),
+        showlegend=False
     )
     return pio.to_html(fig, full_html=False, include_plotlyjs=False)
 
@@ -296,15 +306,16 @@ def _get_priority_distribution_chart_html(priority_data: dict) -> str:
         labels=priority_series.index,
         values=priority_series.values,
         hole=.3,
-        hoverinfo='label+percent+value',
-        textinfo='percent+label'
+        hoverinfo='label+percent',
+        textinfo='label+percent'
     )])
 
     fig.update_layout(
-        title_text="问题优先级分布",
-        margin=dict(t=40, l=20, r=20, b=20),
-        showlegend=False,
-        height=200
+        title_text="",
+        margin=dict(t=20, l=20, r=20, b=20),
+        height=240,
+        showlegend=True,
+        legend=dict(orientation="h", yanchor="bottom", y=-0.2, xanchor="center", x=0.5)
     )
 
     return pio.to_html(fig, full_html=False, include_plotlyjs=False)
@@ -380,14 +391,14 @@ def _get_risk_module_bar_chart_html(top_3_modules: list) -> str:
     ))
 
     fig.update_layout(
-        title_text='Top 3 风险模块分布',
+        title_text="",
         xaxis_title="风险问题占比 (%)",
         yaxis_title="模块",
+        height=240,
         margin=dict(l=20, r=20, t=40, b=20),
         xaxis=dict(showgrid=True, zeroline=True, showticklabels=True),
         yaxis=dict(showgrid=False, zeroline=False, showticklabels=True),
-        showlegend=False,
-        height=200
+        showlegend=False
     )
 
     return pio.to_html(fig, full_html=False, include_plotlyjs=False) 


### PR DESCRIPTION
- 将模块分布图从饼图改为水平条形图，解决渲染空白的问题。
- 调整图表容器的CSS，实现标题与图表的垂直居中对齐。
- 优化优先级分布图的图例显示。